### PR TITLE
Separated install.pp into two OS files

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -1,0 +1,35 @@
+class weechat::debian inherits weechat {
+  if $install_upstream_packages {
+    # BEWARE - This will allow unsigned packages to be installed on your system
+    file { "/etc/apt/apt.conf.d/99auth":
+      owner     => root,
+      group     => root,
+      content   => "APT::Get::AllowUnauthenticated yes;",
+      mode      => 644,
+    }
+
+    apt::source { 'weechat':
+      location    => 'http://debian.weechat.org',
+      repos       => 'main',
+      include_src => false,
+    }
+  }
+
+  if $install_upstream_packages and $install_devel_packages {
+    package { [
+               'weechat-devel',
+               'weechat-devel-curses',
+               'weechat-devel-plugins'
+               ]:
+                 ensure => latest,
+    }
+  } else {
+    package { [
+             'weechat',
+             'weechat-curses',
+             'weechat-plugins'
+             ]:
+               ensure => latest,
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,5 +2,5 @@ class weechat (
   $install_upstream_packages = $weechat::params::install_upstream_packages,
   $install_devel_packages    = $weechat::params::install_devel_packages,
 ) inherits weechat::params {
-  include weechat::install
+  include "weechat::$::operatingsystem"
 }

--- a/manifests/ubuntu.pp
+++ b/manifests/ubuntu.pp
@@ -1,5 +1,10 @@
-class weechat::install inherits weechat {
+class weechat::ubuntu inherits weechat {
   if $install_upstream_packages {
+    apt_key { 'puppetlabs':
+      ensure => 'present',
+      id     => '4573289D',
+    }
+
     # BEWARE - This will allow unsigned packages to be installed on your system
     file { "/etc/apt/apt.conf.d/99auth":
       owner     => root,
@@ -9,7 +14,7 @@ class weechat::install inherits weechat {
     }
 
     apt::source { 'weechat':
-      location    => 'http://debian.weechat.org',
+      location    => 'http://ppa.launchpad.net/nesthib/weechat/ubuntu',
       repos       => 'main',
       include_src => false,
     }
@@ -17,11 +22,11 @@ class weechat::install inherits weechat {
 
   if $install_upstream_packages and $install_devel_packages {
     package { [
-               'weechat-devel',
-               'weechat-devel-curses',
-               'weechat-devel-plugins'
+               'weechat',
+               'weechat-curses',
+               'weechat-plugins'
                ]:
-                 ensure => latest,
+                 ensure => '1.1~dev+20141031~precise1',
     }
   } else {
     package { [


### PR DESCRIPTION
The previous config only supported Debian. Ubuntu support was close, but
the launchpad repository has slightly different package names. By separating
into two OS files I've allowed for further configuration. The default
package for Ubuntu is currently 1.1 and is sourced from launchpad as the
current package in Ubuntu's repository (0.3) is unacceptably dated.
